### PR TITLE
Revert "第3章 三角測量"

### DIFF
--- a/lib/dollar.rb
+++ b/lib/dollar.rb
@@ -8,8 +8,4 @@ class Dollar
   def times(multiplier)
     Dollar.new(amount * multiplier)
   end
-
-  def equals(dollar)
-    amount == dollar.amount
-  end
 end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -8,9 +8,4 @@ RSpec.describe 'Money Test', type: :model do
     product = five.times(3)
     expect(product.amount).to eq 15
   end
-
-  it 'Test Equality' do
-    expect(Dollar.new(5).equals(Dollar.new(5))).to be true
-    expect(Dollar.new(5).equals(Dollar.new(6))).to be false
-  end
 end


### PR DESCRIPTION
Reverts kano-e/reading-tdd#3

`#equals` メソッドの追加ではなく `#==` のオーバーライドが、本の中でやりたいことに近いと気づいた。
#4 で実装し直した。