### PR TITLE
第4章 意図を語るテスト

### DIFF
--- a/lib/dollar.rb
+++ b/lib/dollar.rb
@@ -1,6 +1,4 @@
 class Dollar
-  attr_accessor :amount
-
   def initialize(amount)
     self.amount = amount
   end
@@ -12,4 +10,7 @@ class Dollar
   def ==(dollar)
     amount == dollar.amount
   end
+
+  private
+  attr_accessor :amount
 end

--- a/lib/dollar.rb
+++ b/lib/dollar.rb
@@ -1,4 +1,6 @@
 class Dollar
+  attr_accessor :amount
+
   def initialize(amount)
     self.amount = amount
   end
@@ -10,7 +12,4 @@ class Dollar
   def ==(dollar)
     amount == dollar.amount
   end
-
-  private
-  attr_accessor :amount
 end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Money Test', type: :model do
     product = five.times(2)
     expect(product).to eq Dollar.new(10)
     product = five.times(3)
-    expect(product.amount).to eq 15
+    expect(product).to eq Dollar.new(15)
   end
 
   it 'Test Equality' do

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Money Test', type: :model do
   it 'Test Multiplication' do
     five = Dollar.new(5)
     product = five.times(2)
-    expect(product.amount).to eq 10
+    expect(product).to eq Dollar.new(10)
     product = five.times(3)
     expect(product.amount).to eq 15
   end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -3,10 +3,8 @@ require 'dollar'
 RSpec.describe 'Money Test', type: :model do
   it 'Test Multiplication' do
     five = Dollar.new(5)
-    product = five.times(2)
-    expect(product).to eq Dollar.new(10)
-    product = five.times(3)
-    expect(product).to eq Dollar.new(15)
+    expect(five.times(2)).to eq Dollar.new(10)
+    expect(five.times(3)).to eq Dollar.new(15)
   end
 
   it 'Test Equality' do


### PR DESCRIPTION
* 作成したばかりの機能を使ってテストを改善した
    * #4 で追加した `#==` のこと
    * `.to eq` できるようになったことで、 spec ファイルから `Dollar#amount` を参照する必要がなくなった
    * そのことで、より意図が明確な (`#times` を実行した戻り値が `Dollar` インスタンスと同じものである) テストになった
* そもそも正しく検証できていないテストが2つあったら、もはやお手上げだと気づいた
    * 「等価性比較が正確に実装されていることを検証できていなかったのならば、掛け算のテストもきちんと掛け算ができていることを検証できていない」
    * POODR であった「自分より変更されないものに依存しなさい」(第3章「依存方向の選択」)にも通じるかな
* そのようなリスクを受け入れて先に進んだ
    * それらのリスクは「あるもの」として、それでも進まないといけないよね、ということと受け取った
    * リスクが顕在化した時にも「ではどのようなテストがあれば良かったのか」ということから考えることができる
    * 「教訓をかたちに」は、問題をテストにすることで議論できる状態になる (これは https://github.com/kano-e/reading-tdd/pull/2#issuecomment-343125182 で出てきたことに近い)
* テスト対象オブジェクトの新しい機能を使い、テストコードとプロダクトコードの結合度を下げた
    * こっちは `#amount` を `private` にした件だと思う
    * まあ、なってないんだけど
    * そういえば最初に `attr_accessor` にしちゃったけど、そこまでは必要ないよね
    * せめて `attr_reader` だけにする？