### PR TITLE
第8章 実装を隠す

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,6 +1,10 @@
 class Money
   attr_accessor :amount
 
+  def self.dollar(amount)
+    Dollar.new(amount)
+  end
+
   def ==(money)
     amount == money.amount && self.instance_of?(money.class)
   end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -5,6 +5,10 @@ class Money
     Dollar.new(amount)
   end
 
+  def self.franc(amount)
+    Franc.new(amount)
+  end
+
   def times(multipiler)
     raise NotImplementedError, "This #{self.class} cannot respond to:"
   end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -5,6 +5,10 @@ class Money
     Dollar.new(amount)
   end
 
+  def times(multipiler)
+    raise NotImplementedError, "This #{self.class} cannot respond to:"
+  end
+
   def ==(money)
     amount == money.amount && self.instance_of?(money.class)
   end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe 'Money Test', type: :model do
   it 'Test Equality' do
     expect(Money.dollar(5)).to eq Money.dollar(5)
     expect(Money.dollar(5)).not_to eq Money.dollar(6)
-    expect(Franc.new(5)).to eq Franc.new(5)
-    expect(Franc.new(5)).not_to eq Franc.new(6)
-    expect(Franc.new(5)).not_to eq Money.dollar(5)
+    expect(Money.franc(5)).to eq Money.franc(5)
+    expect(Money.franc(5)).not_to eq Money.franc(6)
+    expect(Money.franc(5)).not_to eq Money.dollar(5)
   end
 
   it 'Test Franc Multiplication' do
-    five = Franc.new(5)
-    expect(five.times(2)).to eq Franc.new(10)
-    expect(five.times(3)).to eq Franc.new(15)
+    five = Money.franc(5)
+    expect(five.times(2)).to eq Money.franc(10)
+    expect(five.times(3)).to eq Money.franc(15)
   end
 end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -4,16 +4,16 @@ require 'franc'
 RSpec.describe 'Money Test', type: :model do
   it 'Test Multiplication' do
     five = Money.dollar(5)
-    expect(five.times(2)).to eq Dollar.new(10)
-    expect(five.times(3)).to eq Dollar.new(15)
+    expect(five.times(2)).to eq Money.dollar(10)
+    expect(five.times(3)).to eq Money.dollar(15)
   end
 
   it 'Test Equality' do
-    expect(Dollar.new(5)).to eq Dollar.new(5)
-    expect(Dollar.new(5)).not_to eq Dollar.new(6)
+    expect(Money.dollar(5)).to eq Money.dollar(5)
+    expect(Money.dollar(5)).not_to eq Money.dollar(6)
     expect(Franc.new(5)).to eq Franc.new(5)
     expect(Franc.new(5)).not_to eq Franc.new(6)
-    expect(Franc.new(5)).not_to eq Dollar.new(5)
+    expect(Franc.new(5)).not_to eq Money.dollar(5)
   end
 
   it 'Test Franc Multiplication' do

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -3,7 +3,7 @@ require 'franc'
 
 RSpec.describe 'Money Test', type: :model do
   it 'Test Multiplication' do
-    five = Dollar.new(5)
+    five = Money.dollar(5)
     expect(five.times(2)).to eq Dollar.new(10)
     expect(five.times(3)).to eq Dollar.new(15)
   end


### PR DESCRIPTION
* ~~重複を除去できる状態に一歩近づけるために、 Dollar と Franc にある 2 つの times メソッドのシグニチャを合わせた~~
* せめて宣言だけは親クラスに移動した
    * 📝 NotImplementedError を使って、 Money に `#times` のテンプレートメソッドを用意した
    * 📝 Money を継承したクラスは `#times` メソッドを実装する必要がある
* Factory Method パターンを導入して、テストコードから 2 つのサブクラスの存在を隠した
* サブクラスを隠した結果、いくつかのテストが冗長なものになったことに気がついたが、いまはそのままにしておいた