### PR TITLE
第11章 不要になったら消す

### DIFF
--- a/lib/dollar.rb
+++ b/lib/dollar.rb
@@ -1,4 +1,0 @@
-require 'money'
-
-class Dollar < Money
-end

--- a/lib/franc.rb
+++ b/lib/franc.rb
@@ -1,4 +1,0 @@
-require 'money'
-
-class Franc < Money
-end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -2,11 +2,11 @@ class Money
   attr_accessor :amount
 
   def self.dollar(amount)
-    Dollar.new(amount, 'USD')
+    Money.new(amount, 'USD')
   end
 
   def self.franc(amount)
-    Franc.new(amount, 'CHF')
+    Money.new(amount, 'CHF')
   end
 
   def initialize(amount, currency)

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -1,4 +1,4 @@
-require 'dollar'
+require 'money'
 require 'franc'
 
 RSpec.describe 'Money Test', type: :model do

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -1,5 +1,4 @@
 require 'money'
-require 'franc'
 
 RSpec.describe 'Money Test', type: :model do
   it 'Test Multiplication' do
@@ -23,9 +22,5 @@ RSpec.describe 'Money Test', type: :model do
   it 'Test #currency' do
     expect(Money.dollar(1).currency).to eq 'USD'
     expect(Money.franc(1).currency).to eq 'CHF'
-  end
-
-  it 'Test Different Class Equality' do
-    expect(Money.new(10, 'CHF')).to eq Franc.new(10, 'CHF')
   end
 end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -13,12 +13,6 @@ RSpec.describe 'Money Test', type: :model do
     expect(Money.franc(5)).not_to eq Money.dollar(5)
   end
 
-  it 'Test Franc Multiplication' do
-    five = Money.franc(5)
-    expect(five.times(2)).to eq Money.franc(10)
-    expect(five.times(3)).to eq Money.franc(15)
-  end
-
   it 'Test #currency' do
     expect(Money.dollar(1).currency).to eq 'USD'
     expect(Money.franc(1).currency).to eq 'CHF'

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe 'Money Test', type: :model do
   it 'Test Equality' do
     expect(Money.dollar(5)).to eq Money.dollar(5)
     expect(Money.dollar(5)).not_to eq Money.dollar(6)
-    expect(Money.franc(5)).to eq Money.franc(5)
-    expect(Money.franc(5)).not_to eq Money.franc(6)
     expect(Money.franc(5)).not_to eq Money.dollar(5)
   end
 


### PR DESCRIPTION
* サブクラスの仕事を減らし続け、とうとう消すところまでたどり着いた
* サブクラス削除前の構造では意味があるものの、削除後は冗長になってしまうテストたちを消した
    * テスト消すのは難しい
    * 実装途中で一時的に安心を得るために追加したテストは、実装後に忘れずに間違いなく消そうって思った
    * 今回のケースだと Franc Multiplication のテストを不要と判断して消すのは勇気と覚悟が必要な気がする